### PR TITLE
TRE-358 : Custom Date Range Screens

### DIFF
--- a/src/test/scala/uk/gov/hmrc/ui/pages/REQ_10_ReportNamePage.scala
+++ b/src/test/scala/uk/gov/hmrc/ui/pages/REQ_10_ReportNamePage.scala
@@ -19,5 +19,5 @@ package uk.gov.hmrc.ui.pages
 import org.openqa.selenium.By
 
 object REQ_10_ReportNamePage extends BasePage("/report-name", "What name will you use to identify this report?") {
-  val inputReportName = By.cssSelector("input.govuk-input")
+  val inputReportName: By = By.cssSelector("input.govuk-input")
 }

--- a/src/test/scala/uk/gov/hmrc/ui/pages/REQ_10_ReportNamePage.scala
+++ b/src/test/scala/uk/gov/hmrc/ui/pages/REQ_10_ReportNamePage.scala
@@ -16,4 +16,8 @@
 
 package uk.gov.hmrc.ui.pages
 
-object REQ_4_ReportSubtypeSelectionPage extends BasePage("/report-type", "Which type of report do you need?") {}
+import org.openqa.selenium.By
+
+object REQ_10_ReportNamePage extends BasePage("/report-name", "What name will you use to identify this report?") {
+  val inputReportName = By.cssSelector("input.govuk-input")
+}

--- a/src/test/scala/uk/gov/hmrc/ui/pages/REQ_11_ChooseToAddEmailPage.scala
+++ b/src/test/scala/uk/gov/hmrc/ui/pages/REQ_11_ChooseToAddEmailPage.scala
@@ -17,4 +17,7 @@
 package uk.gov.hmrc.ui.pages
 
 object REQ_11_ChooseToAddEmailPage
-    extends BasePage("/choose-email-address", "Do you want to add another email for notifications?") {}
+    extends BasePage(
+      "/choose-email-address",
+      "Do you want to add another email for notifications?"
+    ) {} // -- 24 April 2024: URL is incorrect. Correction is pending tech cleanup sweep (TRE-358).

--- a/src/test/scala/uk/gov/hmrc/ui/pages/REQ_11_ChooseToAddEmailPage.scala
+++ b/src/test/scala/uk/gov/hmrc/ui/pages/REQ_11_ChooseToAddEmailPage.scala
@@ -16,5 +16,5 @@
 
 package uk.gov.hmrc.ui.pages
 
-object REQ_7_ChooseToAddEmailPage
+object REQ_11_ChooseToAddEmailPage
     extends BasePage("/choose-email-address", "Do you want to add another email for notifications?") {}

--- a/src/test/scala/uk/gov/hmrc/ui/pages/REQ_12_SelectEmails.scala
+++ b/src/test/scala/uk/gov/hmrc/ui/pages/REQ_12_SelectEmails.scala
@@ -16,5 +16,5 @@
 
 package uk.gov.hmrc.ui.pages
 
-object REQ_5_ReportDateRangeDecisionPage
-    extends BasePage("/date-rage", "What date range do you want the report to cover?") {}
+object REQ_12_SelectEmailsPage
+    extends BasePage("/notification-email", "Which email address do you want to receive notifications?") {}

--- a/src/test/scala/uk/gov/hmrc/ui/pages/REQ_4_ReportOwnerTypePage.scala
+++ b/src/test/scala/uk/gov/hmrc/ui/pages/REQ_4_ReportOwnerTypePage.scala
@@ -16,5 +16,5 @@
 
 package uk.gov.hmrc.ui.pages
 
-object REQ_3_ReportOwnerTypePage
+object REQ_4_ReportOwnerTypePage
     extends BasePage("/request-cds-report/eoriRole", "What is the owner of the EORI number’s role in the report?") {}

--- a/src/test/scala/uk/gov/hmrc/ui/pages/REQ_4_ReportOwnerTypePage.scala
+++ b/src/test/scala/uk/gov/hmrc/ui/pages/REQ_4_ReportOwnerTypePage.scala
@@ -17,4 +17,7 @@
 package uk.gov.hmrc.ui.pages
 
 object REQ_4_ReportOwnerTypePage
-    extends BasePage("/request-cds-report/eoriRole", "What is the owner of the EORI number’s role in the report?") {}
+    extends BasePage(
+      "/request-cds-report/eoriRole",
+      "What is the owner of the EORI number’s role in the report?"
+    ) {} // -- 24 April 2024: URL is incorrect. Correction is pending tech cleanup sweep (TRE-358).

--- a/src/test/scala/uk/gov/hmrc/ui/pages/REQ_5_ReportSubtypeSelectionPage.scala
+++ b/src/test/scala/uk/gov/hmrc/ui/pages/REQ_5_ReportSubtypeSelectionPage.scala
@@ -16,4 +16,8 @@
 
 package uk.gov.hmrc.ui.pages
 
-object REQ_5_ImportTypeSelectionPage extends BasePage("/report-type", "Which type of report do you need?") {}
+object REQ_5_ImportTypeSelectionPage
+    extends BasePage(
+      "/report-type",
+      "Which type of report do you need?"
+    ) {} // -- 24 April 2024: URL is incorrect. Correction is pending tech cleanup sweep (TRE-358).

--- a/src/test/scala/uk/gov/hmrc/ui/pages/REQ_5_ReportSubtypeSelectionPage.scala
+++ b/src/test/scala/uk/gov/hmrc/ui/pages/REQ_5_ReportSubtypeSelectionPage.scala
@@ -16,5 +16,4 @@
 
 package uk.gov.hmrc.ui.pages
 
-object REQ_8_SelectEmailsPage
-    extends BasePage("/notification-email", "Which email address do you want to receive notifications?") {}
+object REQ_5_ImportTypeSelectionPage extends BasePage("/report-type", "Which type of report do you need?") {}

--- a/src/test/scala/uk/gov/hmrc/ui/pages/REQ_7_ReportDateRangeDecisionPage.scala
+++ b/src/test/scala/uk/gov/hmrc/ui/pages/REQ_7_ReportDateRangeDecisionPage.scala
@@ -16,8 +16,5 @@
 
 package uk.gov.hmrc.ui.pages
 
-import org.openqa.selenium.By
-
-object REQ_6_ReportNamePage extends BasePage("/report-name", "What name will you use to identify this report?") {
-  val inputReportName = By.cssSelector("input.govuk-input")
-}
+object REQ_7_ReportDateRangeDecisionPage
+    extends BasePage("/date-rage", "What date range do you want the report to cover?") {}

--- a/src/test/scala/uk/gov/hmrc/ui/pages/REQ_8_ReportCustomDateRangeStartPage.scala
+++ b/src/test/scala/uk/gov/hmrc/ui/pages/REQ_8_ReportCustomDateRangeStartPage.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.ui.pages
+
+import org.openqa.selenium.By
+
+object REQ_8_ReportCustomDateRangeStartPage
+    extends BasePage("/start-date", "Which date do you want your report to start?") {
+        val inputCustomDay: By = By.cssSelector("input[name='value.day']")
+        val inputCustomMonth: By = By.cssSelector("input[name='value.month']")
+        val inputCustomYear: By = By.cssSelector("input[name='value.year']")
+    }

--- a/src/test/scala/uk/gov/hmrc/ui/pages/REQ_8_ReportCustomDateRangeStartPage.scala
+++ b/src/test/scala/uk/gov/hmrc/ui/pages/REQ_8_ReportCustomDateRangeStartPage.scala
@@ -20,7 +20,7 @@ import org.openqa.selenium.By
 
 object REQ_8_ReportCustomDateRangeStartPage
     extends BasePage("/start-date", "Which date do you want your report to start?") {
-        val inputCustomDay: By = By.cssSelector("input[name='value.day']")
-        val inputCustomMonth: By = By.cssSelector("input[name='value.month']")
-        val inputCustomYear: By = By.cssSelector("input[name='value.year']")
-    }
+  val inputCustomDay: By   = By.cssSelector("input[name='value.day']")
+  val inputCustomMonth: By = By.cssSelector("input[name='value.month']")
+  val inputCustomYear: By  = By.cssSelector("input[name='value.year']")
+}

--- a/src/test/scala/uk/gov/hmrc/ui/pages/REQ_9_ReportCustomDateRangeEndPage.scala
+++ b/src/test/scala/uk/gov/hmrc/ui/pages/REQ_9_ReportCustomDateRangeEndPage.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.ui.pages
+
+import org.openqa.selenium.By
+
+object REQ_9_ReportCustomDateRangeEndPage
+    extends BasePage("/end-date", "Which date do you want your report to end?") {
+        val inputCustomDay: By = By.cssSelector("input[name='value.day']")
+        val inputCustomMonth: By = By.cssSelector("input[name='value.month']")
+        val inputCustomYear: By = By.cssSelector("input[name='value.year']")
+    }

--- a/src/test/scala/uk/gov/hmrc/ui/pages/REQ_9_ReportCustomDateRangeEndPage.scala
+++ b/src/test/scala/uk/gov/hmrc/ui/pages/REQ_9_ReportCustomDateRangeEndPage.scala
@@ -18,9 +18,8 @@ package uk.gov.hmrc.ui.pages
 
 import org.openqa.selenium.By
 
-object REQ_9_ReportCustomDateRangeEndPage
-    extends BasePage("/end-date", "Which date do you want your report to end?") {
-        val inputCustomDay: By = By.cssSelector("input[name='value.day']")
-        val inputCustomMonth: By = By.cssSelector("input[name='value.month']")
-        val inputCustomYear: By = By.cssSelector("input[name='value.year']")
-    }
+object REQ_9_ReportCustomDateRangeEndPage extends BasePage("/end-date", "Which date do you want your report to end?") {
+  val inputCustomDay: By   = By.cssSelector("input[name='value.day']")
+  val inputCustomMonth: By = By.cssSelector("input[name='value.month']")
+  val inputCustomYear: By  = By.cssSelector("input[name='value.year']")
+}

--- a/src/test/scala/uk/gov/hmrc/ui/specs/RequestReportSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/ui/specs/RequestReportSpec.scala
@@ -26,12 +26,12 @@ class RequestReportSpec extends BaseSpec {
   private val requestReportPage           = REQ_0_RequestReportPage
   private val reportTypePage              = REQ_1_ReportTypePage
   private val whichEORIPage               = REQ_2_WhichEORIPage
-  private val reportOwnerTypePage         = REQ_3_ReportOwnerTypePage
-  private val reportSubTypePage           = REQ_4_ReportSubtypeSelectionPage
-  private val reportDateRangeDecisionPage = REQ_5_ReportDateRangeDecisionPage
-  private val reportNamePage              = REQ_6_ReportNamePage
-  private val chooseEmailPage             = REQ_7_ChooseToAddEmailPage
-  private val selectEmailsPage            = REQ_8_SelectEmailsPage
+  private val reportOwnerTypePage         = REQ_4_ReportOwnerTypePage
+  private val reportImportTypePage        = REQ_5_ImportTypeSelectionPage
+  private val reportDateRangeDecisionPage = REQ_7_ReportDateRangeDecisionPage
+  private val reportNamePage              = REQ_10_ReportNamePage
+  private val chooseEmailPage             = REQ_11_ChooseToAddEmailPage
+  private val selectEmailsPage            = REQ_12_SelectEmailsPage
 
   Feature("The user can request a new report of 'import' type data.") {
 
@@ -80,7 +80,7 @@ class RequestReportSpec extends BaseSpec {
       whichEORIPage.selectOption(0)
     }
 
-    Scenario("REQ-3: The user selects the EORI role.") {
+    Scenario("REQ-4: The user selects the EORI role.") {
       When("the user clicks to continue from the previous page")
       whichEORIPage.continue()
 
@@ -93,21 +93,21 @@ class RequestReportSpec extends BaseSpec {
       reportOwnerTypePage.selectOption(1)
     }
 
-    Scenario("REQ-4: The user selects the sub-type of their 'import' report.") {
+    Scenario("REQ-5: The user selects the sub-type of their 'import' report.") {
       When("the user clicks to continue from the previous page")
       reportOwnerTypePage.continue()
 
       Then("the user is taken to the '(sub)type of report' page")
-      reportSubTypePage.assertUrl()
-      reportSubTypePage.assertPageTitle()
+      reportImportTypePage.assertUrl()
+      reportImportTypePage.assertPageTitle()
 
       And("the user can select the 'import header' type.")
-      reportSubTypePage.selectOption(0)
+      reportImportTypePage.selectOption(0)
     }
 
-    Scenario("REQ-5: The user selects the date range of their report.") {
+    Scenario("REQ-7: The user selects the date range of their report.") {
       When("the user clicks to continue from the previous page")
-      reportSubTypePage.continue()
+      reportImportTypePage.continue()
 
       Then("the user is taken to the 'report date range decision' page")
       reportDateRangeDecisionPage.assertUrl()
@@ -117,9 +117,11 @@ class RequestReportSpec extends BaseSpec {
       reportDateRangeDecisionPage.selectOption(2)
     }
 
-    Scenario("REQ-12: The user gives a custom date range for their report.")(pending)
+    Scenario("REQ-8: The user gives a custom 'start' date range for their report.")(pending)
 
-    Scenario("REQ-6: The user enters a name for their report.") {
+    Scenario("REQ-9: The user gives a custom 'end' date range for their report.")(pending)
+
+    Scenario("REQ-10: The user enters a name for their report.") {
       When("the user clicks to continue from the previous page")
       reportDateRangeDecisionPage.continue()
 
@@ -131,7 +133,7 @@ class RequestReportSpec extends BaseSpec {
       reportNamePage.clearAndInputKeys(reportNamePage.inputReportName, "a")
     }
 
-    Scenario("REQ 7: The user selects whether to add another email for notifications.") {
+    Scenario("REQ 11: The user selects whether to add another email for notifications.") {
       When("the user clicks to continue from the previous page")
       reportNamePage.continue()
 
@@ -143,7 +145,7 @@ class RequestReportSpec extends BaseSpec {
       chooseEmailPage.selectYesNo(0)
     }
 
-    Scenario("REQ 8: The user selects what emails are to receive notifications.") {
+    Scenario("REQ 12: The user selects what emails are to receive notifications.") {
       When("the user clicks to continue from the previous page")
       chooseEmailPage.continue()
 
@@ -155,13 +157,15 @@ class RequestReportSpec extends BaseSpec {
       selectEmailsPage.selectOption(2)
     }
 
-    Scenario("The user adds a new email.")(pending)
+    Scenario("REQ-13: The user adds a new email.")(pending)
 
-    Scenario("The user reaches the confirmation screen.")(pending)
+    Scenario("REQ-14: The user reaches the confirmation screen.")(pending)
+
+    Scenario("REQ-15: The user successfully submits")(pending)
   }
 
-  Feature("ACC-1: The user can request a new report of 'export' type data.") {
-    Scenario("The user is authenticated.") {
+  Feature("The user can request a new report of 'export' type data.") {
+    Scenario("ACC-1: The user is authenticated.") {
       When("the user logs in using an organisation with a known enrolment")
       loginPage.navigateTo()
       loginPage.enterRedirectionUrl()

--- a/src/test/scala/uk/gov/hmrc/ui/specs/RequestReportSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/ui/specs/RequestReportSpec.scala
@@ -29,6 +29,8 @@ class RequestReportSpec extends BaseSpec {
   private val reportOwnerTypePage         = REQ_4_ReportOwnerTypePage
   private val reportImportTypePage        = REQ_5_ImportTypeSelectionPage
   private val reportDateRangeDecisionPage = REQ_7_ReportDateRangeDecisionPage
+  private val ReportCustomStartPage       = REQ_8_ReportCustomDateRangeStartPage
+  private val ReportCustomEndPage         = REQ_9_ReportCustomDateRangeEndPage
   private val reportNamePage              = REQ_10_ReportNamePage
   private val chooseEmailPage             = REQ_11_ChooseToAddEmailPage
   private val selectEmailsPage            = REQ_12_SelectEmailsPage
@@ -117,9 +119,33 @@ class RequestReportSpec extends BaseSpec {
       reportDateRangeDecisionPage.selectOption(2)
     }
 
-    Scenario("REQ-8: The user gives a custom 'start' date range for their report.")(pending)
+    Scenario("REQ-8: The user gives a custom 'start' date range for their report.") {
+      When("the user clicks to continue from the previous page")
+      reportDateRangeDecisionPage.continue()
 
-    Scenario("REQ-9: The user gives a custom 'end' date range for their report.")(pending)
+      Then("the user is taken to the 'custom report range start' page")
+      ReportCustomStartPage.assertUrl()
+      ReportCustomStartPage.assertPageTitle()
+
+      And("the user can enter the value '1st April 2025'.")
+      ReportCustomStartPage.clearAndInputKeys(ReportCustomStartPage.inputCustomDay, "1")
+      ReportCustomStartPage.clearAndInputKeys(ReportCustomStartPage.inputCustomMonth, "4")
+      ReportCustomStartPage.clearAndInputKeys(ReportCustomStartPage.inputCustomYear, "2025")
+    }
+
+    Scenario("REQ-9: The user gives a custom 'end' date range for their report.") {
+      When("the user clicks to continue from the previous page")
+      ReportCustomStartPage.continue()
+
+      Then("the user is taken to the 'custom report range end' page")
+      ReportCustomEndPage.assertUrl()
+      ReportCustomEndPage.assertPageTitle()
+
+      And("the user can enter the value '2nd April 2025'.")
+      ReportCustomEndPage.clearAndInputKeys(ReportCustomEndPage.inputCustomDay, "2")
+      ReportCustomEndPage.clearAndInputKeys(ReportCustomEndPage.inputCustomMonth, "4")
+      ReportCustomEndPage.clearAndInputKeys(ReportCustomEndPage.inputCustomYear, "2025")
+    }
 
     Scenario("REQ-10: The user enters a name for their report.") {
       When("the user clicks to continue from the previous page")
@@ -127,7 +153,7 @@ class RequestReportSpec extends BaseSpec {
 
       Then("the user is taken to the 'report name' page")
       reportNamePage.assertUrl()
-      // reportNamePage.assertPageTitle() -- 17 April 2024: Title is incorrect. Correction is pending tech cleanup sweep.
+      // reportNamePage.assertPageTitle() -- 24 April 2024: Title is incorrect. Correction is pending tech cleanup sweep (TRE-358).
 
       And("the user can enter text into the text box")
       reportNamePage.clearAndInputKeys(reportNamePage.inputReportName, "a")


### PR DESCRIPTION
Updated the codes for the pages to match the content documents and the mural, then added the newest implemented custom date range pages (which have now been broken into two) as perquisite work for TRE-345.