### PR TITLE
TRE-405: Change to Journey

### DIFF
--- a/src/test/scala/uk/gov/hmrc/ui/specs/RequestReportSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/ui/specs/RequestReportSpec.scala
@@ -38,7 +38,7 @@ class RequestReportSpec extends BaseSpec {
   private val checkYourAnswersPage        = REQ_14_CheckYourAnswersPage
   private val requestSubmittedPage        = REQ_15_ReportRequestSubmittedPage
 
-  Feature("The user can request a new report of 'import' type data.") {
+  Feature("The user can request a new report of 'import'-type data and use their own EORI number to complete the journey.") {
 
     Scenario("ACC-1: The user is authenticated.") {
       When("the user logs in using an organisation with a known enrolment")
@@ -61,7 +61,7 @@ class RequestReportSpec extends BaseSpec {
       requestReportPage.assertPageTitle()
     }
 
-    Scenario("REQ-1: The user selects the type of data.") {
+    Scenario("REQ-1: The user selects 'import' as the type of data.") {
       When("the user clicks to continue from the previous page")
       requestReportPage.continue()
 
@@ -93,8 +93,8 @@ class RequestReportSpec extends BaseSpec {
       reportOwnerTypePage.assertUrl()
       reportOwnerTypePage.assertPageTitle()
 
-      And("the user can select both the 'Declarant' and 'Importer' roles.")
-      reportOwnerTypePage.selectOption(0)
+      And("the user can select the 'Importer' role.")
+      reportOwnerTypePage.assertOptionText(1, "Importer")
       reportOwnerTypePage.selectOption(1)
     }
 
@@ -114,7 +114,7 @@ class RequestReportSpec extends BaseSpec {
       When("the user clicks to continue from the previous page")
       reportImportTypePage.continue()
 
-      Then("the user is taken to the 'report date range decision' page")
+      Then("the user is taken to the 'report date range' page")
       reportDateRangeDecisionPage.assertUrl()
       reportDateRangeDecisionPage.assertPageTitle()
 
@@ -226,38 +226,48 @@ class RequestReportSpec extends BaseSpec {
     }
   }
 
-  Feature("The user can request a new report of 'export' type data.") {
-    Scenario("ACC-1: The user is authenticated.") {
-      When("the user logs in using an organisation with a known enrolment")
-      loginPage.navigateTo()
-      loginPage.enterRedirectionUrl()
-      loginPage.enterEnrollment(anOrganisationUserWithKnownEnrolment)
-      loginPage.continue()
-
-      Then("the user should be taken to the dashboard.")
-      dashboardPage.assertUrl()
-      dashboardPage.assertPageTitle()
-    }
-
-    Scenario("REQ-0: The user starts the 'Request New Report' journey.") {
-      When("the user clicks the link on the dashboard")
-      dashboardPage.selectLink(dashboardPage.linkRequestNewReport)
-
-      Then("the user should be taken to the information page")
-      requestReportPage.assertUrl()
-      requestReportPage.assertPageTitle()
-    }
-
-    Scenario("REQ-1: The user selects the type of data.") {
-      When("the user clicks to continue from the previous page")
-      requestReportPage.continue()
-
-      Then("the user should be taken to the 'Data Download Type' page")
+  Feature("The user can request a new report of 'export'-type data and use their own EORI number to reach the 'date range' screen.") {
+    Scenario("REQ-1: The user selects 'export' as the type of data.") {
+      Given("the user is already on the 'Data Download Type' page")
+      reportTypePage.navigateTo()
       reportTypePage.assertUrl()
-      reportTypePage.assertPageTitle()
 
-      And("the user should be able to select 'export' as a type")
-      reportTypePage.selectOption(0)
+      Then("the user can select 'export' as a type")
+      reportTypePage.selectOption(1)
+    }
+
+    Scenario("REQ-2: The user selects to use their own EORI number.") {
+      When("the user clicks to continue from the previous page")
+      reportTypePage.continue()
+
+      Then("the user is taken to the 'Which EORI' page")
+      whichEORIPage.assertUrl()
+      whichEORIPage.assertPageTitle()
+
+      And("the user can select to use their own EORI number.")
+      whichEORIPage.selectOption(0)
+    }
+
+    Scenario("REQ-4: The user selects the EORI role.") {
+      When("the user clicks to continue from the previous page")
+      whichEORIPage.continue()
+
+      Then("the user is taken to the 'EORI Role' page")
+      reportOwnerTypePage.assertUrl()
+      reportOwnerTypePage.assertPageTitle()
+
+      And("the user can select the 'Exporter' role.")
+      reportOwnerTypePage.assertOptionText(1, "Exporter")
+      reportOwnerTypePage.selectOption(1)
+    }
+
+    Scenario("REQ-7: The user is skipped to the 'report date range' page.") {
+      When("the user clicks to continue from the previous page")
+      reportOwnerTypePage.continue()
+
+      Then("the user is taken to the 'report date range' page")
+      reportDateRangeDecisionPage.assertUrl()
+      reportDateRangeDecisionPage.assertPageTitle()
     }
 
     Scenario("REQ-2: The user selects to use an EORI number they have authority over.")(pending)

--- a/src/test/scala/uk/gov/hmrc/ui/specs/RequestReportSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/ui/specs/RequestReportSpec.scala
@@ -218,7 +218,7 @@ class RequestReportSpec extends BaseSpec {
       requestSubmittedPage.assertUrl()
     }
 
-    Scenario("[F1] END: The user successfully returns to the Dashboard") {
+    Scenario("[F1] (END) The user successfully returns to the Dashboard") {
       When("the user clicks to return to the homepage")
       requestSubmittedPage.ClickLinkHomepage()
 
@@ -229,7 +229,7 @@ class RequestReportSpec extends BaseSpec {
   }
 
   Feature(
-    "[F2] The user can request a new report of 'export'-type data and use their own EORI number to reach the 'date range' screen."
+    "[F2] The user can request a new report of 'export'-type data and use their own EORI number."
   ) {
     Scenario("[F2] REQ-1: The user selects 'export' as the type of data.") {
       Given("the user is already on the 'Data Download Type' page")
@@ -265,7 +265,7 @@ class RequestReportSpec extends BaseSpec {
       reportOwnerTypePage.selectOption(1)
     }
 
-    Scenario("[F2] REQ-7: The user is skipped to the 'report date range' page.") {
+    Scenario("[F2] (END) REQ-7: The user is skipped to the 'report date range' page.") {
       When("the user clicks to continue from the previous page")
       reportOwnerTypePage.continue()
 
@@ -273,16 +273,31 @@ class RequestReportSpec extends BaseSpec {
       reportDateRangeDecisionPage.assertUrl()
       reportDateRangeDecisionPage.assertPageTitle()
     }
+  }
 
-    Scenario("REQ-2: The user selects to use an EORI number they have authority over.")(pending)
-    // 29 April 2025 -- The content for this page is changing from dropdown to radio buttons.
+  Feature(
+    "[F3] The user can request a new report of 'import'-type data but use a third-party EORI number."
+  ) {
+    Scenario("[F3] REQ-1: The user selects 'import' as the type of data.")(pending)
 
-    Scenario("REQ-3: The user selects the EORI number they have authority to use.")(pending)
+    Scenario("[F3] REQ-2: The user selects to use an EORI number they have authority over.")(pending)
 
-    Scenario("REQ-4: The user selects the EORI role.")(pending)
+    Scenario("[F3] REQ-3: The user selects the desired third party EORI.")(pending)
+    // 29 April 2025 -- The content for this page is changing from dropdown to radio buttons. So we might as well wait for this change (dropdowns not used anywhere else).
 
-    Scenario("REQ-6 (END): The user selects the sub-type of their 'export' report.")(pending)
+    Scenario("[F3] (END) REQ-5: The user is skipped to selecting the sub-type of their 'import' report.")(pending)
+  }
 
-    // End of this Feature spec -- the rest of journey from this point is covered by the first Feature spec.
+  Feature(
+    "[F4] The user can request a new report of 'export'-type data but use a third-party EORI number."
+  ) {
+    Scenario("[F4] REQ-1: The user selects 'export' as the type of data.")(pending)
+
+    Scenario("[F4] REQ-2: The user selects to use an EORI number they have authority over.")(pending)
+
+    Scenario("[F4] REQ-3: The user selects the desired third party EORI.")(pending)
+    // 29 April 2025 -- The content for this page is changing from dropdown to radio buttons. So we might as well wait for this change (dropdowns not used anywhere else).
+
+    Scenario("[F4] (END) REQ-7: The user is skipped to the 'report date range' page.")(pending)
   }
 }

--- a/src/test/scala/uk/gov/hmrc/ui/specs/RequestReportSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/ui/specs/RequestReportSpec.scala
@@ -38,7 +38,9 @@ class RequestReportSpec extends BaseSpec {
   private val checkYourAnswersPage        = REQ_14_CheckYourAnswersPage
   private val requestSubmittedPage        = REQ_15_ReportRequestSubmittedPage
 
-  Feature("The user can request a new report of 'import'-type data and use their own EORI number to complete the journey.") {
+  Feature(
+    "The user can request a new report of 'import'-type data and use their own EORI number to complete the journey."
+  ) {
 
     Scenario("ACC-1: The user is authenticated.") {
       When("the user logs in using an organisation with a known enrolment")
@@ -226,7 +228,9 @@ class RequestReportSpec extends BaseSpec {
     }
   }
 
-  Feature("The user can request a new report of 'export'-type data and use their own EORI number to reach the 'date range' screen.") {
+  Feature(
+    "The user can request a new report of 'export'-type data and use their own EORI number to reach the 'date range' screen."
+  ) {
     Scenario("REQ-1: The user selects 'export' as the type of data.") {
       Given("the user is already on the 'Data Download Type' page")
       reportTypePage.navigateTo()

--- a/src/test/scala/uk/gov/hmrc/ui/specs/RequestReportSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/ui/specs/RequestReportSpec.scala
@@ -39,10 +39,10 @@ class RequestReportSpec extends BaseSpec {
   private val requestSubmittedPage        = REQ_15_ReportRequestSubmittedPage
 
   Feature(
-    "The user can request a new report of 'import'-type data and use their own EORI number to complete the journey."
+    "[F1] The user can request a new report of 'import'-type data and use their own EORI number to complete the journey."
   ) {
 
-    Scenario("ACC-1: The user is authenticated.") {
+    Scenario("[F1] ACC-1: The user is authenticated.") {
       When("the user logs in using an organisation with a known enrolment")
       loginPage.navigateTo()
       loginPage.enterRedirectionUrl()
@@ -54,7 +54,7 @@ class RequestReportSpec extends BaseSpec {
       dashboardPage.assertPageTitle()
     }
 
-    Scenario("REQ-0: The user starts the 'Request New Report' journey.") {
+    Scenario("[F1] REQ-0: The user starts the 'Request New Report' journey.") {
       When("the user clicks the link on the dashboard")
       dashboardPage.selectLink(dashboardPage.linkRequestNewReport)
 
@@ -63,7 +63,7 @@ class RequestReportSpec extends BaseSpec {
       requestReportPage.assertPageTitle()
     }
 
-    Scenario("REQ-1: The user selects 'import' as the type of data.") {
+    Scenario("[F1] REQ-1: The user selects 'import' as the type of data.") {
       When("the user clicks to continue from the previous page")
       requestReportPage.continue()
 
@@ -75,7 +75,7 @@ class RequestReportSpec extends BaseSpec {
       reportTypePage.selectOption(0)
     }
 
-    Scenario("REQ-2: The user selects to use their own EORI number.") {
+    Scenario("[F1] REQ-2: The user selects to use their own EORI number.") {
       When("the user clicks to continue from the previous page")
       reportTypePage.continue()
 
@@ -87,7 +87,7 @@ class RequestReportSpec extends BaseSpec {
       whichEORIPage.selectOption(0)
     }
 
-    Scenario("REQ-4: The user selects the EORI role.") {
+    Scenario("[F1] REQ-4: The user selects the EORI role.") {
       When("the user clicks to continue from the previous page")
       whichEORIPage.continue()
 
@@ -100,7 +100,7 @@ class RequestReportSpec extends BaseSpec {
       reportOwnerTypePage.selectOption(1)
     }
 
-    Scenario("REQ-5: The user selects the sub-type of their 'import' report.") {
+    Scenario("[F1] REQ-5: The user selects the sub-type of their 'import' report.") {
       When("the user clicks to continue from the previous page")
       reportOwnerTypePage.continue()
 
@@ -112,7 +112,7 @@ class RequestReportSpec extends BaseSpec {
       reportImportTypePage.selectOption(0)
     }
 
-    Scenario("REQ-7: The user selects the date range of their report.") {
+    Scenario("[F1] REQ-7: The user selects the date range of their report.") {
       When("the user clicks to continue from the previous page")
       reportImportTypePage.continue()
 
@@ -124,7 +124,7 @@ class RequestReportSpec extends BaseSpec {
       reportDateRangeDecisionPage.selectOption(2)
     }
 
-    Scenario("REQ-8: The user gives a custom 'start' date range for their report.") {
+    Scenario("[F1] REQ-8: The user gives a custom 'start' date range for their report.") {
       When("the user clicks to continue from the previous page")
       reportDateRangeDecisionPage.continue()
 
@@ -138,7 +138,7 @@ class RequestReportSpec extends BaseSpec {
       ReportCustomStartPage.clearAndInputKeys(ReportCustomStartPage.inputCustomYear, "2025")
     }
 
-    Scenario("REQ-9: The user gives a custom 'end' date range for their report.") {
+    Scenario("[F1] REQ-9: The user gives a custom 'end' date range for their report.") {
       When("the user clicks to continue from the previous page")
       ReportCustomStartPage.continue()
 
@@ -152,7 +152,7 @@ class RequestReportSpec extends BaseSpec {
       ReportCustomEndPage.clearAndInputKeys(ReportCustomEndPage.inputCustomYear, "2025")
     }
 
-    Scenario("REQ-10: The user enters a name for their report.") {
+    Scenario("[F1] REQ-10: The user enters a name for their report.") {
       When("the user clicks to continue from the previous page")
       reportDateRangeDecisionPage.continue()
 
@@ -164,7 +164,7 @@ class RequestReportSpec extends BaseSpec {
       reportNamePage.clearAndInputKeys(reportNamePage.inputReportName, "a")
     }
 
-    Scenario("REQ 11: The user selects whether to add another email for notifications.") {
+    Scenario("[F1] REQ 11: The user selects whether to add another email for notifications.") {
       When("the user clicks to continue from the previous page")
       reportNamePage.continue()
 
@@ -176,7 +176,7 @@ class RequestReportSpec extends BaseSpec {
       chooseEmailPage.selectYesNo(0)
     }
 
-    Scenario("REQ 12: The user selects what emails are to receive notifications.") {
+    Scenario("[F1] REQ 12: The user selects what emails are to receive notifications.") {
       When("the user clicks to continue from the previous page")
       chooseEmailPage.continue()
 
@@ -188,7 +188,7 @@ class RequestReportSpec extends BaseSpec {
       selectEmailsPage.selectOption(2)
     }
 
-    Scenario("REQ 13: The user adds a new email.") {
+    Scenario("[F1] REQ 13: The user adds a new email.") {
       When("the user clicks to continue from the previous page")
       selectEmailsPage.continue()
 
@@ -200,7 +200,7 @@ class RequestReportSpec extends BaseSpec {
       enterNewEmailPage.clearAndInputKeys(enterNewEmailPage.inputNewEmailAddress, "abc@gmail.com")
     }
 
-    Scenario("REQ-14: The user reaches the confirmation screen.") {
+    Scenario("[F1] REQ-14: The user reaches the confirmation screen.") {
       When("the user clicks to continue from the previous page")
       enterNewEmailPage.continue()
 
@@ -209,7 +209,7 @@ class RequestReportSpec extends BaseSpec {
       checkYourAnswersPage.assertUrl()
     }
 
-    Scenario("REQ-15: The user successfully submits") {
+    Scenario("[F1] REQ-15: The user successfully submits") {
       When("the user clicks to continue from the previous page")
       checkYourAnswersPage.continue()
 
@@ -218,7 +218,7 @@ class RequestReportSpec extends BaseSpec {
       requestSubmittedPage.assertUrl()
     }
 
-    Scenario("END: The user successfully returns to the Dashboard") {
+    Scenario("[F1] END: The user successfully returns to the Dashboard") {
       When("the user clicks to return to the homepage")
       requestSubmittedPage.ClickLinkHomepage()
 
@@ -229,9 +229,9 @@ class RequestReportSpec extends BaseSpec {
   }
 
   Feature(
-    "The user can request a new report of 'export'-type data and use their own EORI number to reach the 'date range' screen."
+    "[F2] The user can request a new report of 'export'-type data and use their own EORI number to reach the 'date range' screen."
   ) {
-    Scenario("REQ-1: The user selects 'export' as the type of data.") {
+    Scenario("[F2] REQ-1: The user selects 'export' as the type of data.") {
       Given("the user is already on the 'Data Download Type' page")
       reportTypePage.navigateTo()
       reportTypePage.assertUrl()
@@ -240,7 +240,7 @@ class RequestReportSpec extends BaseSpec {
       reportTypePage.selectOption(1)
     }
 
-    Scenario("REQ-2: The user selects to use their own EORI number.") {
+    Scenario("[F2] REQ-2: The user selects to use their own EORI number.") {
       When("the user clicks to continue from the previous page")
       reportTypePage.continue()
 
@@ -252,7 +252,7 @@ class RequestReportSpec extends BaseSpec {
       whichEORIPage.selectOption(0)
     }
 
-    Scenario("REQ-4: The user selects the EORI role.") {
+    Scenario("[F2] REQ-4: The user selects the EORI role.") {
       When("the user clicks to continue from the previous page")
       whichEORIPage.continue()
 
@@ -265,7 +265,7 @@ class RequestReportSpec extends BaseSpec {
       reportOwnerTypePage.selectOption(1)
     }
 
-    Scenario("REQ-7: The user is skipped to the 'report date range' page.") {
+    Scenario("[F2] REQ-7: The user is skipped to the 'report date range' page.") {
       When("the user clicks to continue from the previous page")
       reportOwnerTypePage.continue()
 


### PR DESCRIPTION
Added some additional Features to the Spec to capture the slight differences in the RequestReport journey when the user selects 'import' or 'export' and whether they're using their own EORI number or third party (an EORI they have authority over).

Due to pending changes with the selection screen from radio to dropdown, the two Features which go through this are set as 'pending' -- Nowhere else uses a dropdown, so there's little point right now in working out how to select from/test it.