### PR TITLE
Fix-20250624: Added Invalid Enrolment for Unauthorised Tests

### DIFF
--- a/src/test/scala/support/builders/EnrolmentsDataBuilder.scala
+++ b/src/test/scala/support/builders/EnrolmentsDataBuilder.scala
@@ -25,4 +25,10 @@ object EnrolmentsDataBuilder {
     identifierName = "EORINumber",
     identifierValue = "GB123456789020"
   )
+
+  val anInvalidEnrolmentsData: EnrolmentsData = EnrolmentsData(
+    enrolmentKey = "HMRC-CUS-ORG",
+    identifierName = "EORINumber",
+    identifierValue = "1"
+  )
 }

--- a/src/test/scala/support/builders/UserCredentialsBuilder.scala
+++ b/src/test/scala/support/builders/UserCredentialsBuilder.scala
@@ -16,7 +16,7 @@
 
 package support.builders
 
-import support.builders.EnrolmentsDataBuilder.anEnrolmentsData
+import support.builders.EnrolmentsDataBuilder.{anEnrolmentsData, anInvalidEnrolmentsData}
 import uk.gov.hmrc.ui.models._
 
 object UserCredentialsBuilder {
@@ -39,4 +39,7 @@ object UserCredentialsBuilder {
 
   val anOrganisationUserWithKnownEnrolment: UserCredentials =
     aUserCredentials.copy(affinityGroup = Organisation, enrolmentsData = Some(anEnrolmentsData))
+
+  val anOrganisationUserWithInvalidEnrolment: UserCredentials =
+    aUserCredentials.copy(affinityGroup = Organisation, enrolmentsData = Some(anInvalidEnrolmentsData))
 }

--- a/src/test/scala/uk/gov/hmrc/ui/specs/UnauthorisedSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/ui/specs/UnauthorisedSpec.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.ui.specs
 
 import uk.gov.hmrc.ui.pages._
+import support.builders.UserCredentialsBuilder.anOrganisationUserWithInvalidEnrolment
 
 class UnauthorisedSpec extends BaseSpec {
 
@@ -28,6 +29,7 @@ class UnauthorisedSpec extends BaseSpec {
       Given("the user is not authenticated")
       loginPage.navigateTo()
       loginPage.enterRedirectionUrl()
+      loginPage.enterEnrollment(anOrganisationUserWithInvalidEnrolment)
       loginPage.continue()
 
       Then("the user encounters the 'unauthorised' page")


### PR DESCRIPTION
Added a new data for a "invalid" enrolment to prompt the unauthorised page, allowing the test to hit it.