### PR TITLE
TRE-660: Update Request Report journey with skipped email screen

### DIFF
--- a/src/test/scala/uk/gov/hmrc/ui/specs_support/REQ_RequestReportSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/ui/specs_support/REQ_RequestReportSpec.scala
@@ -222,6 +222,10 @@ class REQ_RequestReportSpec(enrollmentToUse: UserCredentials) extends BaseSpec {
         enterNewEmailPage.assertPageTitle()
       }
 
+      // QA Note:
+      // REQ-12 is skipped if the account has no additional email address associated.
+      // An email will need to be added earlier on in the tests/by direct DB editing.
+
       // Scenario("[F1] REQ 12: The user selects what emails are to receive notifications.") {
       //   Given("the user selects the 'Add new email address' option")
       //   selectEmailsPage.selectOptionByValue(selectEmailsPage.inputAddNewEmail)

--- a/src/test/scala/uk/gov/hmrc/ui/specs_support/REQ_RequestReportSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/ui/specs_support/REQ_RequestReportSpec.scala
@@ -214,26 +214,29 @@ class REQ_RequestReportSpec(enrollmentToUse: UserCredentials) extends BaseSpec {
         When("the user clicks to continue")
         chooseEmailPage.continue()
 
-        Then("the user is taken to the 'choose to add email' page")
-        selectEmailsPage.assertUrl()
-        selectEmailsPage.assertPageTitle()
-      }
-
-      Scenario("[F1] REQ 12: The user selects what emails are to receive notifications.") {
-        Given("the user selects the 'Add new email address' option")
-        selectEmailsPage.selectOptionByValue(selectEmailsPage.inputAddNewEmail)
-
-        When("the user clicks to continue")
-        selectEmailsPage.continue()
-
+        // Then("the user is taken to the 'choose to add email' page")
+        // selectEmailsPage.assertUrl()
+        // selectEmailsPage.assertPageTitle()
         Then("the user is taken to the 'Enter new email address' page")
         enterNewEmailPage.assertUrl()
         enterNewEmailPage.assertPageTitle()
       }
 
+      // Scenario("[F1] REQ 12: The user selects what emails are to receive notifications.") {
+      //   Given("the user selects the 'Add new email address' option")
+      //   selectEmailsPage.selectOptionByValue(selectEmailsPage.inputAddNewEmail)
+
+      //   When("the user clicks to continue")
+      //   selectEmailsPage.continue()
+
+      //   Then("the user is taken to the 'Enter new email address' page")
+      //   enterNewEmailPage.assertUrl()
+      //   enterNewEmailPage.assertPageTitle()
+      // }
+
       Scenario("[F1] REQ 13: The user adds a new email.") {
         Given("the user enters the new email address in the text box")
-        enterNewEmailPage.clearAndInputKeys("abc@gmail.com")
+        enterNewEmailPage.clearAndInputKeys("myexample@email.com")
 
         When("the user clicks to continue")
         enterNewEmailPage.continue()


### PR DESCRIPTION
The email screen is now skipped when the account logged in does not have an additional email address.

As this is not yet achievable naturally in a journey and dynamic DB editing is not set up yet, I have just commented out the associated test and put a reminder for later.